### PR TITLE
Beta notice + GitHub-issue feedback + backtest i18n fix

### DIFF
--- a/backend/app/api/v1/endpoints/backtest.py
+++ b/backend/app/api/v1/endpoints/backtest.py
@@ -50,6 +50,7 @@ class CounterfactualResult(BaseModel):
     name_cn: str
     name_en: str
     notes: str
+    notes_en: str
     params: Dict
     skipped_count: int
     actual_total_pnl: float
@@ -74,6 +75,7 @@ def _to_response(result, cfg) -> CounterfactualResult:
         name_cn=cfg.name_cn,
         name_en=cfg.name_en,
         notes=result.notes,
+        notes_en=result.notes_en,
         params=result.params,
         skipped_count=result.skipped_count,
         actual_total_pnl=result.actual_total_pnl,

--- a/backend/app/services/counterfactual.py
+++ b/backend/app/services/counterfactual.py
@@ -52,6 +52,7 @@ class RuleResult:
     monthly: List[Dict]  # [{month: "2025-04", actual_pnl, cf_pnl, savings}, ...]
     skipped_by_symbol: Dict[str, int]
     notes: str = ""
+    notes_en: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -98,6 +99,7 @@ def _assemble_result(
     positions: List[Position],
     skipped_ids: List[int],
     notes: str = "",
+    notes_en: str = "",
 ) -> RuleResult:
     skip_set = set(skipped_ids)
     actual_by_m, counter_by_m = _build_monthly(positions, skip_set)
@@ -140,6 +142,7 @@ def _assemble_result(
         monthly=monthly_rows,
         skipped_by_symbol=dict(by_sym),
         notes=notes,
+        notes_en=notes_en,
     )
 
 
@@ -182,6 +185,10 @@ def cf1_consecutive_loss_cutoff(
         notes=(
             f"对每个标的，连续 {n} 笔亏损后跳过该标的所有后续交易。"
             f"触发熔断的标的：{len(cutoff_after_id)} 个。"
+        ),
+        notes_en=(
+            f"Per ticker, skip all later trades on it after {n} consecutive losses. "
+            f"Tickers that triggered the cutoff: {len(cutoff_after_id)}."
         ),
     )
 
@@ -228,6 +235,10 @@ def cf2_no_revenge_trading(
         notes=(
             f"任何亏损平仓后 {hours} 小时内开的新仓视为报复性交易，全部跳过。"
         ),
+        notes_en=(
+            f"Any position opened within {hours}h of a losing exit is treated as "
+            f"revenge trading and skipped."
+        ),
     )
 
 
@@ -267,6 +278,12 @@ def cf3_avoid_persistent_losers(
         notes=(
             f"完全避开胜率 < {max_win_rate*100:.0f}% 且总盈亏 < 0 的标的"
             f"（最少 {min_trades} 笔样本）。识别出 {len(bad_symbols)} 个标的："
+            f"{', '.join(sorted(bad_symbols)[:8])}{'...' if len(bad_symbols)>8 else ''}"
+        ),
+        notes_en=(
+            f"Fully avoid tickers with win rate < {max_win_rate*100:.0f}% and "
+            f"negative total P&L (min {min_trades} trades). "
+            f"Identified {len(bad_symbols)} tickers: "
             f"{', '.join(sorted(bad_symbols)[:8])}{'...' if len(bad_symbols)>8 else ''}"
         ),
     )
@@ -361,6 +378,11 @@ def cf4_position_size_cap(
             f"单笔仓位金额超过历史中位数的 {cap_multiple}× 时按比例缩小，"
             f"模拟仓位管理对总盈亏的影响。命中 {len(capped_positions)} 笔。"
         ),
+        notes_en=(
+            f"Scale down any position larger than {cap_multiple}× the historical "
+            f"median size, simulating position-size management. "
+            f"{len(capped_positions)} positions affected."
+        ),
     )
 
 
@@ -436,6 +458,10 @@ def cf5_hard_stop_loss(
         notes=(
             f"对任何亏损超过 {threshold_pct}% 的仓位，假设当时严格止损在 "
             f"{threshold_pct}%。命中 {len(capped)} 笔。"
+        ),
+        notes_en=(
+            f"For any position that lost more than {threshold_pct}%, assume a hard "
+            f"stop at {threshold_pct}%. {len(capped)} positions affected."
         ),
     )
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -760,6 +760,7 @@ export interface BacktestResult {
   name_cn: string;
   name_en: string;
   notes: string;
+  notes_en: string;
   params: Record<string, number>;
   skipped_count: number;
   actual_total_pnl: number;

--- a/frontend/src/components/feedback/FeedbackButton.tsx
+++ b/frontend/src/components/feedback/FeedbackButton.tsx
@@ -31,6 +31,7 @@ export function FeedbackButton() {
   const [description, setDescription] = useState('');
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>('idle');
   const [errorMessage, setErrorMessage] = useState('');
+  const [issueUrl, setIssueUrl] = useState<string | null>(null);
 
   const handleSubmit = async () => {
     if (!title.trim()) return;
@@ -48,14 +49,16 @@ export function FeedbackButton() {
       });
 
       if (response.data.success) {
+        setIssueUrl(response.data.issue_url ?? null);
         setSubmitStatus('success');
-        // 3秒后关闭并重置
+        // 关闭并重置（留足时间让用户点击 issue 链接）
         setTimeout(() => {
           setTitle('');
           setDescription('');
           setIsOpen(false);
           setSubmitStatus('idle');
-        }, 2000);
+          setIssueUrl(null);
+        }, 6000);
       }
     } catch (error) {
       setSubmitStatus('error');
@@ -122,8 +125,18 @@ export function FeedbackButton() {
                   {isZh ? '感谢你的反馈！' : 'Thank you for your feedback!'}
                 </h4>
                 <p className="text-sm text-slate-500 dark:text-white/60">
-                  {isZh ? '我们已收到你的反馈，会尽快处理。' : 'We have received your feedback and will review it soon.'}
+                  {isZh ? '已自动提交为 GitHub Issue，会尽快处理。' : 'Filed as a GitHub issue — we will review it soon.'}
                 </p>
+                {issueUrl && (
+                  <a
+                    href={issueUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-block mt-4 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                  >
+                    {isZh ? '查看 Issue →' : 'View issue →'}
+                  </a>
+                )}
               </div>
             ) : (
               <>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -94,6 +94,9 @@ export function Sidebar() {
             <span className="text-sm font-mono font-bold tracking-widest text-slate-900 dark:text-white uppercase">
               TC_TERMINAL
             </span>
+            <span className="ml-2 px-1.5 py-0.5 rounded-sm border border-amber-400/60 bg-amber-400/10 text-amber-600 dark:text-amber-400 text-[9px] font-mono font-bold tracking-widest uppercase">
+              Beta
+            </span>
           </div>
           {/* Mobile Close Button */}
           <button

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -101,6 +101,8 @@ export default {
     heroSubtitle: 'Try the sample workspace first, then upload your own broker CSV when you are ready.',
     systemStatus: 'System Operational',
     version: 'v',
+    betaTag: 'Public Beta',
+    betaNotice: "You're using the public beta — found a bug or have an idea? Use the feedback button (bottom-right); it files a GitHub issue.",
     trySampleData: 'Try Sample Data',
     uploadYourCsv: 'Upload Your CSV',
     sampleLoadFailed: 'Sample workspace failed to load. Please try again.',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -101,6 +101,8 @@ export default {
     heroSubtitle: '先用样本数据快速体验，再上传自己的券商 CSV 做真实复盘。',
     systemStatus: '系统运行中',
     version: '版本',
+    betaTag: '公开 Beta',
+    betaNotice: '当前为公开 Beta 测试版 —— 发现问题或有想法？点右下角反馈按钮，会直接提交到 GitHub Issue。',
     trySampleData: '试用样本数据',
     uploadYourCsv: '上传 CSV',
     sampleLoadFailed: '样本工作区加载失败，请重试。',

--- a/frontend/src/pages/Backtest.test.tsx
+++ b/frontend/src/pages/Backtest.test.tsx
@@ -60,6 +60,7 @@ describe('Backtest', () => {
         name_cn: '严格止损 -X%',
         name_en: 'Hard stop -X%',
         notes: '对任何亏损超过 -10.0% 的仓位，假设当时严格止损在 -10.0%。',
+        notes_en: 'For any position that lost more than -10.0%, assume a hard stop at -10.0%.',
         params: { stop_loss_pct: -10 },
         skipped_count: 112,
         actual_total_pnl: 4590.21,

--- a/frontend/src/pages/Backtest.tsx
+++ b/frontend/src/pages/Backtest.tsx
@@ -237,7 +237,7 @@ export function Backtest() {
                       </span>
                     </div>
                     <p className="mt-1 text-xs text-slate-500 dark:text-white/50 font-mono truncate">
-                      {r.notes}
+                      {isZh ? r.notes : (r.notes_en || r.notes)}
                     </p>
                   </div>
                 </div>

--- a/frontend/src/pages/LandingUpload.tsx
+++ b/frontend/src/pages/LandingUpload.tsx
@@ -354,8 +354,9 @@ export function LandingUpload() {
 
           {/* Hero - The "Monolith" */}
           <div className="text-center mb-12 relative z-10 pt-2">
-            <div className="inline-block border border-white/20 px-4 py-1.5 rounded-full mb-6 bg-black/50 backdrop-blur">
-              <span className="text-xs font-mono text-white/70 uppercase tracking-widest">{t('landing.systemStatus')} • {t('landing.version')} 1.0.0</span>
+            <div className="inline-flex items-center gap-2 border border-white/20 px-4 py-1.5 rounded-full mb-6 bg-black/50 backdrop-blur">
+              <span className="px-1.5 py-0.5 rounded-sm bg-amber-400/15 border border-amber-400/50 text-amber-300 text-[10px] font-mono font-bold uppercase tracking-widest">{t('landing.betaTag')}</span>
+              <span className="text-xs font-mono text-white/70 uppercase tracking-widest">{t('landing.systemStatus')}</span>
             </div>
 
             <h1 className="text-5xl md:text-7xl font-bold text-white mb-5 tracking-tighter leading-[0.9] whitespace-pre-line">
@@ -397,6 +398,10 @@ export function LandingUpload() {
                 {t('landing.sampleLoadFailed')}
               </p>
             )}
+
+            <p className="mt-6 mx-auto max-w-xl text-xs text-white/40 leading-relaxed">
+              {t('landing.betaNotice')}
+            </p>
           </div>
 
           <div className="max-w-4xl mx-auto w-full relative z-10 px-6 pb-24">


### PR DESCRIPTION
## Changes
1. **Beta notice**: BETA badge in the sidebar (every app page) and the landing hero; a landing line explaining this is a public beta and pointing to the feedback button.
2. **Feedback → GitHub issue**: the global feedback button already files GitHub issues via `/api/v1/feedback`; now the success state shows the created issue link.
3. **Backtest mixed-language fix**: rule `notes` was Chinese-only and rendered raw (mixed languages in EN mode). Now bilingual end-to-end (`notes_en` through service → API → frontend).

## Verified
- frontend `npm run typecheck` clean
- `Backtest.test.tsx` passes
- backend counterfactual rules emit `notes_en`

🤖 Generated with [Claude Code](https://claude.com/claude-code)