### PR TITLE
AI Coach beta: insights-only + bilingual summary

### DIFF
--- a/backend/app/api/v1/endpoints/ai_coach.py
+++ b/backend/app/api/v1/endpoints/ai_coach.py
@@ -77,6 +77,7 @@ async def get_proactive_insights(
     date_start: Optional[date] = Query(default=None, description="开始日期"),
     date_end: Optional[date] = Query(default=None, description="结束日期"),
     limit: int = Query(default=10, ge=1, le=20, description="返回洞察数量上限"),
+    lang: str = Query(default="zh", description="摘要语言: zh 或 en"),
     db: Session = Depends(get_db)
 ):
     """
@@ -89,7 +90,8 @@ async def get_proactive_insights(
         response = await coach.get_proactive_insights(
             date_start=date_start,
             date_end=date_end,
-            limit=limit
+            limit=limit,
+            lang=lang
         )
         return response.to_dict()
     except ValueError as e:
@@ -100,9 +102,14 @@ async def get_proactive_insights(
             date_end=date_end,
             limit=limit
         )
+        unavailable = (
+            "Rule-engine insights below (AI summary service unavailable)."
+            if lang == "en"
+            else "以下是规则引擎生成的洞察（AI 摘要服务暂不可用）。"
+        )
         return {
             "insights": [i.dict() for i in insights],
-            "ai_summary": f"AI 服务暂不可用: {str(e)}。以下是规则引擎生成的洞察。",
+            "ai_summary": unavailable,
             "key_metrics": {},
             "date_range": {
                 "start": str(date_start) if date_start else "all",

--- a/backend/app/services/ai_coach.py
+++ b/backend/app/services/ai_coach.py
@@ -164,7 +164,8 @@ class AICoach:
         self,
         date_start: Optional[date] = None,
         date_end: Optional[date] = None,
-        limit: int = 10
+        limit: int = 10,
+        lang: str = "zh"
     ) -> ProactiveInsightResponse:
         """
         获取主动推送的洞察
@@ -204,7 +205,7 @@ class AICoach:
             date_range_str = "无数据"
 
         # 5. 生成 AI 总结
-        ai_summary = await self._generate_summary(insights, metrics, date_range_str)
+        ai_summary = await self._generate_summary(insights, metrics, date_range_str, lang)
 
         return ProactiveInsightResponse(
             insights=insights,
@@ -222,11 +223,21 @@ class AICoach:
         self,
         insights: List[TradingInsight],
         metrics: Dict[str, Any],
-        date_range: str
+        date_range: str,
+        lang: str = "zh"
     ) -> str:
         """使用 LLM 生成洞察总结"""
         if not insights:
-            return "暂无足够数据生成分析报告。请确保有足够的交易记录。"
+            return (
+                "Not enough data to generate an analysis report yet. "
+                "Please make sure there are enough trades."
+                if lang == "en"
+                else "暂无足够数据生成分析报告。请确保有足够的交易记录。"
+            )
+
+        # 未配置 LLM 时直接走规则引擎降级总结（双语）
+        if self.llm_client is None:
+            return self._generate_fallback_summary(insights, metrics, lang)
 
         # 将洞察转换为 JSON 格式
         insights_json = json.dumps(
@@ -266,41 +277,42 @@ class AICoach:
         except Exception as e:
             logger.error(f"Failed to generate AI summary: {e}")
             # 降级：返回简单总结
-            return self._generate_fallback_summary(insights, metrics)
+            return self._generate_fallback_summary(insights, metrics, lang)
 
     def _generate_fallback_summary(
         self,
         insights: List[TradingInsight],
-        metrics: Dict[str, Any]
+        metrics: Dict[str, Any],
+        lang: str = "zh"
     ) -> str:
-        """生成降级版本的总结（不使用 LLM）"""
+        """生成降级版本的总结（不使用 LLM）。
+
+        保持单一语种：只用指标和洞察计数组成一句话概览，不内嵌各洞察的
+        中文标题/描述（详细问题与优势在下方列表里已按当前语言展示）。
+        """
         problems = [i for i in insights if i.type.value == "problem"]
         strengths = [i for i in insights if i.type.value == "strength"]
-
-        summary_parts = []
-
-        # 整体表现
+        total = metrics.get("total_trades", 0)
         win_rate = metrics.get("win_rate", 0)
         total_pnl = metrics.get("total_pnl", 0)
+
+        if lang == "en":
+            pnl_word = "up" if total_pnl > 0 else "down"
+            n_p, n_s = len(problems), len(strengths)
+            issues = f"{n_p} issue" + ("" if n_p == 1 else "s")
+            strs = f"{n_s} strength" + ("" if n_s == 1 else "s")
+            return (
+                f"{total} trades, {win_rate:.1f}% win rate, "
+                f"{pnl_word} ${abs(total_pnl):,.0f}. "
+                f"{issues} and {strs} detected — see the breakdown below."
+            )
+
         pnl_status = "盈利" if total_pnl > 0 else "亏损"
-        summary_parts.append(
-            f"共{metrics.get('total_trades', 0)}笔交易，"
-            f"胜率{win_rate:.1f}%，{pnl_status}${abs(total_pnl):,.0f}。"
+        return (
+            f"共 {total} 笔交易，胜率 {win_rate:.1f}%，"
+            f"{pnl_status} ${abs(total_pnl):,.0f}。"
+            f"检测到 {len(problems)} 个问题、{len(strengths)} 个优势，详见下方。"
         )
-
-        # 问题
-        if problems:
-            summary_parts.append(f"\n\n主要问题：")
-            for p in problems[:2]:
-                summary_parts.append(f"- {p.title}: {p.description}")
-
-        # 优势
-        if strengths:
-            summary_parts.append(f"\n\n优势方面：")
-            for s in strengths[:2]:
-                summary_parts.append(f"- {s.title}: {s.description}")
-
-        return "\n".join(summary_parts)
 
     async def chat(
         self,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -383,6 +383,7 @@ export const aiCoachApi = {
     date_start?: string;
     date_end?: string;
     limit?: number;
+    lang?: string;
   }) => {
     const { data } = await api.get<ProactiveInsightResponse>(
       '/ai-coach/proactive-insights',

--- a/frontend/src/pages/AICoach.tsx
+++ b/frontend/src/pages/AICoach.tsx
@@ -5,7 +5,6 @@ import {
   SparklesIcon,
   ChartBarIcon,
   LightBulbIcon,
-  ChatBubbleLeftRightIcon,
   ExclamationTriangleIcon,
   CheckCircleIcon,
   InformationCircleIcon,
@@ -58,16 +57,11 @@ export function AICoach() {
     refetch,
     isFetching,
   } = useQuery({
-    queryKey: ['ai-coach-proactive-insights'],
-    queryFn: () => aiCoachApi.getProactiveInsights({ limit: 20 }),
+    queryKey: ['ai-coach-proactive-insights', i18n.language],
+    queryFn: () => aiCoachApi.getProactiveInsights({ limit: 20, lang: i18n.language }),
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
-  // Fetch service status
-  const { data: status } = useQuery({
-    queryKey: ['ai-coach-status'],
-    queryFn: () => aiCoachApi.getStatus(),
-  });
 
   // Filter insights
   const filteredInsights = (proactiveData?.insights || []).filter((insight: TradingInsight) => {
@@ -96,25 +90,6 @@ export function AICoach() {
             {t('insights.aiCoach', 'Smart analysis of your trading performance with personalized suggestions')}
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          {/* Service Status Badge */}
-          <div
-            className={`px-3 py-1.5 rounded-full text-xs font-medium flex items-center gap-1.5 ${
-              status?.available
-                ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
-                : 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400'
-            }`}
-          >
-            <span
-              className={`w-2 h-2 rounded-full ${
-                status?.available ? 'bg-green-500' : 'bg-yellow-500'
-              }`}
-            />
-            {status?.available
-              ? `${status.provider} - ${status.model}`
-              : t('aiCoach.serviceUnavailable', 'AI Unavailable')}
-          </div>
-        </div>
       </div>
 
       {/* Tab Navigation */}
@@ -135,17 +110,6 @@ export function AICoach() {
                 {proactiveData.insights.length}
               </span>
             )}
-          </button>
-          <button
-            onClick={() => setActiveTab('chat')}
-            className={`flex items-center gap-2 py-3 px-1 border-b-2 text-sm font-medium transition-colors ${
-              activeTab === 'chat'
-                ? 'border-purple-600 text-purple-600'
-                : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
-            }`}
-          >
-            <ChatBubbleLeftRightIcon className="w-5 h-5" />
-            {t('insights.chat', 'Chat')}
           </button>
         </nav>
       </div>


### PR DESCRIPTION
Drops the unwired LLM chat for the beta (no 'AI Unavailable' badge) and keeps the rule-based insights. Makes the proactive-insights summary bilingual (`lang` param through service → endpoint → frontend), fixing the Chinese-in-EN-mode summary.

Verified: frontend typecheck + lint clean; backend summary renders EN/ZH correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)