### PR TITLE
fix: AI summary fallback (remove raising guard)

### DIFF
--- a/backend/app/services/ai_coach.py
+++ b/backend/app/services/ai_coach.py
@@ -235,10 +235,6 @@ class AICoach:
                 else "暂无足够数据生成分析报告。请确保有足够的交易记录。"
             )
 
-        # 未配置 LLM 时直接走规则引擎降级总结（双语）
-        if self.llm_client is None:
-            return self._generate_fallback_summary(insights, metrics, lang)
-
         # 将洞察转换为 JSON 格式
         insights_json = json.dumps(
             [


### PR DESCRIPTION
The `llm_client` property raises ValueError when unconfigured; the guard I added accessed it and propagated to the endpoint's generic fallback. Removed — the existing try/except returns the bilingual metrics summary. Verified locally: EN '83 trades, 49.4% win rate, down $18,842…' / ZH equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)