### PR TITLE
First-party funnel analytics

### DIFF
--- a/backend/app/api/v1/endpoints/analytics.py
+++ b/backend/app/api/v1/endpoints/analytics.py
@@ -1,0 +1,132 @@
+"""
+First-party analytics (privacy-light, no third party)
+
+input: anonymous funnel events from the frontend
+output: appended JSONL on the persistent volume + an admin funnel summary
+pos: lets the distribution-lab measure visits → sample → upload without
+     loading a China-blocked third-party script. No PII: anon id + event name.
+
+一旦我被更新，务必更新我的开头注释，以及所属文件夹的README.md
+"""
+
+import json
+import os
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Header, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+router = APIRouter()
+
+# 允许的事件名白名单（防止脏数据 / 滥用塞垃圾）
+ALLOWED_EVENTS = {
+    "page_view",
+    "sample_click",
+    "sample_loaded",
+    "upload_submit",
+    "analysis_complete",
+}
+
+
+def _analytics_file() -> Path:
+    explicit = os.getenv("ANALYTICS_DIR")
+    if explicit:
+        base = Path(explicit)
+    else:
+        ws = os.getenv("WORKSPACE_DATA_DIR", "data/workspaces")
+        base = Path(ws).parent
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "analytics.jsonl"
+
+
+class EventIn(BaseModel):
+    name: str = Field(..., max_length=40)
+    anon_id: Optional[str] = Field(None, max_length=64)
+    path: Optional[str] = Field(None, max_length=200)
+    ref: Optional[str] = Field(None, max_length=120)  # 渠道标记，如 xhs
+
+
+@router.post("/event", status_code=status.HTTP_204_NO_CONTENT)
+async def track_event(event: EventIn, request: Request) -> None:
+    """记录一个匿名事件（fire-and-forget）。未知事件名静默忽略。"""
+    if event.name not in ALLOWED_EVENTS:
+        return None
+    record = {
+        "t": datetime.now(timezone.utc).isoformat(),
+        "ts": time.time(),
+        "name": event.name,
+        "anon": (event.anon_id or "")[:64],
+        "path": (event.path or "")[:200],
+        "ref": (event.ref or "")[:120],
+    }
+    try:
+        with _analytics_file().open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception:
+        # 埋点绝不能影响用户请求
+        pass
+    return None
+
+
+@router.get("/summary")
+async def summary(
+    days: int = 7,
+    x_admin_token: Optional[str] = Header(None, alias="X-Admin-Token"),
+):
+    """漏斗汇总（受 ADMIN_TOKEN 保护）。返回访客/各事件计数 + 转化率。"""
+    admin_token = os.getenv("ADMIN_TOKEN")
+    if admin_token and x_admin_token != admin_token:
+        raise HTTPException(status_code=403, detail="Invalid or missing X-Admin-Token.")
+
+    path = _analytics_file()
+    cutoff = time.time() - days * 86400
+    by_name: Counter = Counter()
+    visitors: set = set()
+    uploaders: set = set()
+    samplers: set = set()
+    by_ref: Counter = Counter()
+    by_day: defaultdict = defaultdict(Counter)
+
+    if path.exists():
+        with path.open(encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    r = json.loads(line)
+                except Exception:
+                    continue
+                if r.get("ts", 0) < cutoff:
+                    continue
+                name = r.get("name", "")
+                anon = r.get("anon") or ""
+                by_name[name] += 1
+                day = (r.get("t") or "")[:10]
+                if day:
+                    by_day[day][name] += 1
+                if anon:
+                    visitors.add(anon)
+                    if name == "upload_submit":
+                        uploaders.add(anon)
+                    if name in ("sample_click", "sample_loaded"):
+                        samplers.add(anon)
+                if r.get("ref"):
+                    by_ref[r["ref"]] += 1
+
+    v = len(visitors)
+    return {
+        "window_days": days,
+        "unique_visitors": v,
+        "events": dict(by_name),
+        "funnel": {
+            "visitors": v,
+            "tried_sample": len(samplers),
+            "uploaded_csv": len(uploaders),
+            "sample_rate": round(len(samplers) / v, 3) if v else 0,
+            "upload_rate": round(len(uploaders) / v, 3) if v else 0,
+        },
+        "by_channel": dict(by_ref),
+        "by_day": {d: dict(c) for d, c in sorted(by_day.items())},
+    }

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -4,7 +4,7 @@ API v1 Router - Aggregates all endpoint routers
 
 from fastapi import APIRouter
 
-from .endpoints import dashboard, positions, trades, market_data, statistics, system, ai_coach, upload, tasks, events, feedback, backtest, workspaces
+from .endpoints import dashboard, positions, trades, market_data, statistics, system, ai_coach, upload, tasks, events, feedback, backtest, workspaces, analytics
 
 api_router = APIRouter()
 
@@ -84,4 +84,10 @@ api_router.include_router(
     backtest.router,
     prefix="/backtest",
     tags=["Counterfactual Backtest"]
+)
+
+api_router.include_router(
+    analytics.router,
+    prefix="/analytics",
+    tags=["Analytics"]
 )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,9 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { useEffect } from 'react';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { Layout } from '@/components/layout/Layout';
 import { ToastContainer } from '@/components/common/Toast';
 import { FeedbackButton } from '@/components/feedback/FeedbackButton';
+import { track } from '@/api/analytics';
 import { LandingUpload } from '@/pages/LandingUpload';
 import { Upload } from '@/pages/Upload';
 import { AnalysisLoading } from '@/pages/AnalysisLoading';
@@ -15,9 +17,18 @@ import { TaskStatus } from '@/pages/TaskStatus';
 import { EventAnalysis } from '@/pages/EventAnalysis';
 import { Backtest } from '@/pages/Backtest';
 
+function RouteTracker() {
+  const location = useLocation();
+  useEffect(() => {
+    track('page_view', { path: location.pathname });
+  }, [location.pathname]);
+  return null;
+}
+
 function App() {
   return (
     <BrowserRouter>
+      <RouteTracker />
       <ToastContainer />
       <FeedbackButton />
       <Routes>

--- a/frontend/src/api/analytics.ts
+++ b/frontend/src/api/analytics.ts
@@ -1,0 +1,61 @@
+/**
+ * First-party, privacy-light analytics.
+ *
+ * Sends anonymous funnel events to our own backend (same-origin via the
+ * Vercel /api proxy) instead of a third-party script — fast and reachable
+ * from mainland China. No PII: a random anon id + event name + path + an
+ * optional channel tag (?ref=xhs) captured on first visit.
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api/v1';
+const ANON_KEY = 'tc_anon_id';
+const REF_KEY = 'tc_ref';
+
+function getAnonId(): string {
+  try {
+    let id = localStorage.getItem(ANON_KEY);
+    if (!id) {
+      id =
+        (crypto as Crypto)?.randomUUID?.() ??
+        `a_${Date.now().toString(36)}${Math.floor(Math.random() * 1e9).toString(36)}`;
+      localStorage.setItem(ANON_KEY, id);
+    }
+    return id;
+  } catch {
+    return 'anon';
+  }
+}
+
+/** Capture ?ref= on first landing and remember it for later events. */
+function getRef(): string {
+  try {
+    const fromUrl = new URLSearchParams(window.location.search).get('ref');
+    if (fromUrl) {
+      localStorage.setItem(REF_KEY, fromUrl.slice(0, 40));
+      return fromUrl.slice(0, 40);
+    }
+    return localStorage.getItem(REF_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+export function track(name: string, extra?: { path?: string }): void {
+  try {
+    const body = JSON.stringify({
+      name,
+      anon_id: getAnonId(),
+      path: extra?.path ?? window.location.pathname,
+      ref: getRef(),
+    });
+    // fire-and-forget; never block or throw into the UI
+    fetch(`${API_BASE}/analytics/event`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    /* no-op */
+  }
+}

--- a/frontend/src/pages/LandingUpload.tsx
+++ b/frontend/src/pages/LandingUpload.tsx
@@ -10,6 +10,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { taskApi, systemApi, uploadApi, workspaceApi } from '@/api/client';
+import { track } from '@/api/analytics';
 import {
   Upload as UploadIcon,
   FileSpreadsheet,
@@ -112,7 +113,9 @@ export function LandingUpload() {
 
   const sampleMutation = useMutation({
     mutationFn: () => workspaceApi.createSample(),
+    onMutate: () => track('sample_click'),
     onSuccess: () => {
+      track('sample_loaded');
       clearTask();
       queryClient.clear();
       navigate('/statistics');
@@ -221,6 +224,7 @@ export function LandingUpload() {
 
   const handleUpload = () => {
     if (selectedFile && canStartAnalysis) {
+      track('upload_submit');
       createTaskMutation.mutate({
         file: selectedFile,
         userEmail: email.trim() || undefined,


### PR DESCRIPTION
Privacy-light, first-party analytics (no third-party script — works from mainland China). Backend appends anonymous events to a JSONL on the volume + an admin funnel summary; frontend tracks page_view / sample_click / upload_submit with a ?ref channel tag (e.g. xhs). Verified: typecheck clean, funnel + admin guard work locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)