### PR TITLE
QA: helpful guidance for non-Futu CSV uploads

### DIFF
--- a/frontend/src/components/upload/ImportPreflightPanel.tsx
+++ b/frontend/src/components/upload/ImportPreflightPanel.tsx
@@ -165,6 +165,15 @@ export function ImportPreflightPanel({
             <span className={`break-all text-xs ${mutedClass}`}>{selectedFileName || result.file_name}</span>
           </div>
 
+          {!canImport && (
+            <p className={`mt-2 text-sm ${mutedClass}`}>
+              {t(
+                'importPreflight.blockedHelp',
+                "We currently support Futu Securities CSV exports. Try another file, or use “Try Sample Data” above to explore the full experience. Broker not supported? Tell us via the feedback button (bottom-right) and we’ll add it."
+              )}
+            </p>
+          )}
+
           <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-4">
             <div className={`rounded-lg border p-3 ${statClass}`}>
               <div className={`flex items-center gap-2 text-xs ${mutedClass}`}>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -232,6 +232,7 @@ export default {
     retry: 'Retry',
     readyTitle: 'Ready to import',
     blockedTitle: 'File cannot be imported',
+    blockedHelp: "We currently support Futu Securities CSV exports. Try another file, or use “Try Sample Data” above to explore the full experience. Broker not supported? Tell us via the feedback button (bottom-right) and we’ll add it.",
     broker: 'Broker',
     unknownBroker: 'Unknown',
     confidence: 'Confidence',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -232,6 +232,7 @@ export default {
     retry: '重试',
     readyTitle: '可以开始导入',
     blockedTitle: '该文件无法导入',
+    blockedHelp: '目前仅支持富途（Futu）导出的 CSV。可以换个文件重试，或点上方「试用样本数据」先体验完整功能；你的券商不在？点右下角反馈按钮告诉我们，会尽快支持。',
     broker: '券商',
     unknownBroker: '未知',
     confidence: '置信度',


### PR DESCRIPTION
QA pass found the product experienceable end-to-end (zero functional bugs). The one launch-readiness gap: a non-Futu CSV dead-ended with no next step. Add bilingual guidance (Futu-only note + Try Sample + feedback/broker-request) so non-Futu visitors don't bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)