### PR TITLE
QA: hide raw backend message in blocked preflight state

### DIFF
--- a/frontend/src/components/upload/ImportPreflightPanel.tsx
+++ b/frontend/src/components/upload/ImportPreflightPanel.tsx
@@ -213,7 +213,7 @@ export function ImportPreflightPanel({
             })}
           </p>
 
-          {messages.length > 0 && (
+          {canImport && messages.length > 0 && (
             <ul className="mt-3 space-y-1 text-sm text-amber-600 dark:text-amber-400">
               {messages.map((message) => (
                 <li key={message}>• {message}</li>


### PR DESCRIPTION
Follow-up to the non-Futu guidance: suppress the raw English backend preflight message in the blocked state (redundant with the friendly guidance, and mixed-language in zh UI). Warnings on importable files still show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)